### PR TITLE
Add docker build and `npm run build` command

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+build
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:8
+
+RUN dpkg --add-architecture i386
+RUN apt-get update
+RUN apt-get -y install wine wine32 --no-install-recommends
+
+WORKDIR /electronapp
+
+COPY package.json .
+RUN npm install --production
+COPY . .

--- a/buildscripts/docker-build.sh
+++ b/buildscripts/docker-build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+cd $(dirname $0)/..
+
+docker build -t safewallet .
+docker run -ti -v $(pwd):/electronapp safewallet /bin/sh -c "npm run build"

--- a/buildscripts/electron-build-linux.sh
+++ b/buildscripts/electron-build-linux.sh
@@ -2,14 +2,16 @@
 ### Build script for Iguana application for Linux x64 platform.
 ### Created by mmaxian, 3/2017
 
-[ -z $SAFEWALLET_VERSION ] && echo "SAFEWALLET_VERSION variable is not set." && exit 0
+cd $(dirname $0)/..
+
+SAFEWALLET_VERSION=$(node -p "require('./package.json').version")
 [ ! -d build ] && mkdir build
 
 echo
 echo "Build script for Iguana application for Linux x64 platform."
 echo "Preparing electron package $SAFEWALLET_VERSION"
 
-electron-packager . --platform=linux --arch=x64 \
+./node_modules/.bin/electron-packager . --platform=linux --arch=x64 \
   --icon=assets/icons/safewallet_icons/128x128.png \
   --out=build/ \
   --buildVersion=$SAFEWALLET_VERSION \

--- a/buildscripts/electron-build-osx.sh
+++ b/buildscripts/electron-build-osx.sh
@@ -2,14 +2,16 @@
 ### Build script for Iguana application for MacOS platform.
 ### Created by mmaxian, 3/2017
 
-[ -z $SAFEWALLET_VERSION ] && echo "SAFEWALLET_VERSION variable is not set." && exit 0
+cd $(dirname $0)/..
+
+SAFEWALLET_VERSION=$(node -p "require('./package.json').version")
 [ ! -d build ] && mkdir build
 
 echo
 echo "Build script for Iguana application for MacOS platform."
 echo "Preparing electron package $SAFEWALLET_VERSION"
 
-electron-packager . --platform=darwin --arch=x64 \
+./node_modules/.bin/electron-packager . --platform=darwin --arch=x64 \
   --icon=assets/icons/safewallet_app_icon.icns \
   --out=build/ --buildVersion=$SAFEWALLET_VERSION \
   --ignore=assets/bin/win64 \

--- a/buildscripts/electron-build-windows.sh
+++ b/buildscripts/electron-build-windows.sh
@@ -2,14 +2,16 @@
 ### Build script for Iguana application for Windows x64 platform.
 ### Created by mmaxian, 3/2017
 
-[ -z $SAFEWALLET_VERSION ] && echo "SAFEWALLET_VERSION variable is not set." && exit 0
+cd $(dirname $0)/..
+
+SAFEWALLET_VERSION=$(node -p "require('./package.json').version")
 [ ! -d build ] && mkdir build
 
 echo
 echo "Build script for Iguana application for Windows x64 platform."
 echo "Preparing electron package $SAFEWALLET_VERSION"
 
-electron-packager . --platform=win32 \
+./node_modules/.bin/electron-packager . --platform=win32 \
   --arch=x64 \
   --icon=assets/icons/safewallet_app_icon.ico \
   --out=build/ \

--- a/package.json
+++ b/package.json
@@ -8,7 +8,11 @@
     "start": "electron .",
     "make-patch": "./make-patch.sh",
     "make-rpm": "node make-rpm.js",
-    "make-deb": "node make-deb.js"
+    "make-deb": "node make-deb.js",
+    "build:osx": "./buildscripts/electron-build-osx.sh",
+    "build:windows": "./buildscripts/electron-build-windows.sh",
+    "build:linux": "./buildscripts/electron-build-linux.sh",
+    "build": "concurrently 'npm run build:osx' 'npm run build:windows' 'npm run build:linux'"
   },
   "repository": "https://github.com/Fair-Exchange/Safewallet/",
   "homepage": "http://supernet.org",
@@ -21,9 +25,11 @@
   "author": "SuperNET",
   "license": "MIT",
   "devDependencies": {
+    "concurrently": "^3.5.1",
     "electron": "1.8.2",
     "electron-installer-debian": "^0.6.0",
-    "electron-installer-redhat": "^0.5.0"
+    "electron-installer-redhat": "^0.5.0",
+    "electron-packager": "^12.0.0"
   },
   "dependencies": {
     "adm-zip": "^0.4.7",


### PR DESCRIPTION
- Move electron-packager into devDeps, no more global install required
- Add Dockerfile based on Abaci's 
- Change SAFEWALLET_VERSION to read from package.json
  - Now change the version through `npm version major|minor|patch`
- Add `npm run build:{platform}` and overall `npm run build` script
- Add `buildscripts/docker-build.sh` which will be run by CI